### PR TITLE
feat(setup): Basic setup complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# dist folder
+dist
+
+# .env file
+.env

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,5 @@
+dev: NODE_ENV=development npm start
+
+nodemon: NODE_ENV=development npm run nodemon
+
+web: NODE_ENV=production npm start

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "nytimes-explorer",
+  "version": "0.0.0",
+  "description": "Use the NYTimes API for visualization",
+  "main": "index.js",
+  "scripts": {
+    "nodemon": "nodemon server",
+    "start": "node server",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ccfcheng/nytimes-explorer.git"
+  },
+  "author": "Cliff Saporta Cheng",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ccfcheng/nytimes-explorer/issues"
+  },
+  "homepage": "https://github.com/ccfcheng/nytimes-explorer#readme",
+  "dependencies": {
+    "react": "15.3.2",
+    "react-dom": "15.3.2",
+    "request": "2.78.0",
+    "webpack": "1.13.3"
+  },
+  "devDependencies": {
+    "nodemon": "1.11.0"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const request = require('request');
+const NYT = require('./nyt');
+
+const PORT = process.env.PORT || 8080;
+const app = express();
+
+console.log('NODE_ENV:', process.env.NODE_ENV);
+console.log('PORT:', process.env.PORT);
+console.log('NYT_ARTICLES_API:', process.env.NYT_ARTICLES_API);
+
+app.get('/', (req, res) => res.send('Hello World'));
+
+app.get('/test', (req, res) => {
+  const urlString = NYT.makeArticlesURL('jeremy lin');
+  request.get(urlString, (err, response, body) => {
+    console.log('err:', err);
+    console.log('response:', response);
+    console.log('body:', body);
+    if (!err && response.statusCode === 200) {
+      res.send(body);
+    }
+  });
+});
+
+app.listen(PORT, () => console.log('Listening on port ', PORT));

--- a/server/nyt.js
+++ b/server/nyt.js
@@ -1,0 +1,21 @@
+const url = require('url');
+
+const ARTICLES_KEY = process.env.NYT_ARTICLES_API;
+
+const makeArticlesURL = (searchStr) => {
+  const urlObj = {
+    protocol: 'http',
+    slashes: true,
+    hostname: 'api.nytimes.com',
+    pathname: '/svc/search/v2/articlesearch.json',
+    query: {
+      q: searchStr,
+      'api-key': process.env.NYT_ARTICLES_API,
+    },
+  };
+  return url.format(urlObj);
+};
+
+module.exports = {
+  makeArticlesURL,
+};


### PR DESCRIPTION
- Express router in place
- Can pull data from NYTimes Articles API
- Closes #1

TODO:
- Utility methods on backend to clean up JSON responses
- Add Mocha/Chai and basic specs
- Setup basic React frontend to render article data
- More backend methods to refine search
- Add other NYTimes API's