### PR TITLE
feat(data): Use built in NYT filters for paring down data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - "6.2.2"
+notifications:
+  email: false

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mocha:watch": "npm run mocha -- --watch",
     "nodemon": "nodemon server",
     "start": "node server",
-    "test": "npm run lint:server"
+    "test": "npm run lint && npm run mocha"
   },
   "repository": {
     "type": "git",
@@ -23,21 +23,43 @@
     "url": "https://github.com/ccfcheng/nytimes-explorer/issues"
   },
   "homepage": "https://github.com/ccfcheng/nytimes-explorer#readme",
+  "babel": {
+    "presets": [
+      "es2015",
+      "react",
+      "stage-1"
+    ]
+  },
   "dependencies": {
+    "autoprefixer": "6.5.3",
+    "babel-cli": "6.18.0",
+    "babel-core": "6.18.2",
+    "babel-eslint": "7.1.0",
+    "babel-loader": "6.2.7",
+    "babel-preset-es2015": "6.18.0",
+    "babel-preset-react": "6.16.0",
+    "babel-preset-stage-1": "6.16.0",
+    "chai": "3.5.0",
+    "exports-loader": "0.6.3",
     "express": "4.14.0",
+    "extract-text-webpack-plugin": "1.0.1",
+    "imports-loader": "0.6.5",
+    "json-loader": "0.5.4",
+    "mocha": "3.1.2",
+    "postcss-loader": "1.1.1",
     "react": "15.3.2",
     "react-dom": "15.3.2",
     "request": "2.78.0",
-    "webpack": "1.13.3"
+    "style-loader": "0.13.1",
+    "webpack": "1.13.3",
+    "whatwg-fetch": "2.0.0"
   },
   "devDependencies": {
-    "chai": "3.5.0",
     "eslint": "3.10.2",
     "eslint-config-airbnb": "13.0.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-react": "6.7.1",
-    "mocha": "3.1.2",
     "nodemon": "1.11.0",
     "webpack-dev-server": "1.16.2"
   }

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,0 +1,31 @@
+const API_ARTICLES_KEY = process.env.NYT_ARTICLES_API || 'DEFAULT_VALUE';
+const API_ARTICLES_PATHNAME = '/svc/search/v2/articlesearch.json';
+const API_HOSTNAME = 'api.nytimes.com';
+
+// Can turn on/off additional fields depending on my application
+const ARTICLE_FIELDS = [
+  'web_url',
+  // 'snippet',
+  'lead_paragraph',
+  // 'abstract',
+  // 'print_page',
+  // 'blog',
+  // 'source',
+  'multimedia',
+  'headline',
+  // 'keywords',
+  'pub_date',
+  'document_type',
+  // 'news_desk',
+  'byline',
+  // 'type_of_material',
+  // '_id',
+  // 'word_count',
+];
+
+module.exports = {
+  API_ARTICLES_KEY,
+  API_ARTICLES_PATHNAME,
+  API_HOSTNAME,
+  ARTICLE_FIELDS,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const request = require('request');
 const NYT = require('./nyt');
 
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.PORT || 1337;
 const app = express();
 
 // console.log('NODE_ENV:', process.env.NODE_ENV);
@@ -12,7 +12,7 @@ const app = express();
 app.get('/', (req, res) => res.send('Hello World'));
 
 app.get('/test', (req, res) => {
-  const urlString = NYT.makeArticlesURL('jeremy lin');
+  const urlString = NYT.makeArticlesURL('steph curry');
   request.get(urlString, (err, response, body) => {
     // console.log('err:', err);
     // console.log('response:', response);
@@ -24,5 +24,5 @@ app.get('/test', (req, res) => {
 });
 
 app.listen(PORT, () => {
-  // console.log('Listening on port ', PORT);
+  console.log('Listening on port ', PORT);
 });

--- a/server/nyt.js
+++ b/server/nyt.js
@@ -1,14 +1,19 @@
 const url = require('url');
+const Constants = require('./constants');
+
+const makeFields = fieldsArray => fieldsArray.join(',');
 
 const makeArticlesURL = (searchStr) => {
   const urlObj = {
     protocol: 'http',
     slashes: true,
-    hostname: 'api.nytimes.com',
-    pathname: '/svc/search/v2/articlesearch.json',
+    hostname: Constants.API_HOSTNAME,
+    pathname: Constants.API_ARTICLES_PATHNAME,
     query: {
       q: searchStr,
-      'api-key': process.env.NYT_ARTICLES_API,
+      fl: makeFields(Constants.ARTICLE_FIELDS),
+      sort: 'newest',
+      'api-key': Constants.API_ARTICLES_KEY,
     },
   };
   return url.format(urlObj);

--- a/test/server.nyt.spec.js
+++ b/test/server.nyt.spec.js
@@ -1,0 +1,10 @@
+const expect = require('chai').expect;
+const NYT = require('../server/nyt');
+
+describe('makeArticlesURL():', () => {
+  it('Should return a correctly formatted URL given a search string:', () => {
+    const myURL = NYT.makeArticlesURL('testing');
+    const expected = 'http://api.nytimes.com/svc/search/v2/articlesearch.json?q=testing&fl=web_url%2Clead_paragraph%2Cmultimedia%2Cheadline%2Cpub_date%2Cdocument_type%2Cbyline&sort=newest&api-key=DEFAULT_VALUE';
+    expect(myURL).to.equal(expected);
+  });
+});


### PR DESCRIPTION
- Add basic Mocha specs
- Remove email notifications from Travis CI
- Add constants.js to store values
- Closes #5
- Closes #6 